### PR TITLE
feat: add "affordable only" option to level filter

### DIFF
--- a/src/store/lib/filtering.ts
+++ b/src/store/lib/filtering.ts
@@ -248,6 +248,13 @@ function filterNonexceptional(card: Card) {
   return !card.exceptional;
 }
 
+function filterAffordable(xp: number): (card: Card) => boolean {
+  return (card: Card) => {
+    const level = cardLevel(card);
+    return xp >= (level ?? 0) * (card.exceptional ? 2 : 1);
+  };
+}
+
 function filterCardLevel(value: [number, number], checkCustomizable = false) {
   return (card: Card) => {
     const level = cardLevel(card);
@@ -259,7 +266,7 @@ function filterCardLevel(value: [number, number], checkCustomizable = false) {
   };
 }
 
-export function filterLevel(filterState: LevelFilter) {
+export function filterLevel(filterState: LevelFilter, xp?: number | null) {
   const filters = [];
 
   if (filterState.range) {
@@ -272,6 +279,10 @@ export function filterLevel(filterState: LevelFilter) {
     } else {
       filters.push(filterNonexceptional);
     }
+  }
+
+  if (filterState.affordableOnly) {
+    filters.push(filterAffordable(xp ?? 0));
   }
 
   const filter = and(filters);

--- a/src/store/slices/lists.ts
+++ b/src/store/slices/lists.ts
@@ -473,6 +473,7 @@ function makeFilterValue(
               range: undefined,
               exceptional: false,
               nonexceptional: false,
+              affordableOnly: undefined,
             },
       );
     }

--- a/src/store/slices/lists.types.ts
+++ b/src/store/slices/lists.types.ts
@@ -21,6 +21,7 @@ export type LevelFilter = {
   range: undefined | [number, number];
   exceptional: boolean;
   nonexceptional: boolean;
+  affordableOnly: undefined | boolean;
 };
 
 export type MultiselectFilter = string[];


### PR DESCRIPTION
closes #121 
Features:
- Show the "Affordable Only" option when editing a deck
- Calculate current available XP by `deck.xp` - `deck.stats.xpRequired`
- Exceptional cards -> XP = level*2
![image](https://github.com/user-attachments/assets/6c761a32-e881-4d3c-95ea-aab6603fa288)