### PR TITLE
fix: it will not appear in other versions of the investigator if deck_limit is 0 or undefined

### DIFF
--- a/src/store/lib/lookup-tables.ts
+++ b/src/store/lib/lookup-tables.ts
@@ -371,6 +371,7 @@ export function createRelations(metadata: Metadata, tables: LookupTables) {
     // Index multi-class investigators.
     if (
       card.type_code === "investigator" &&
+      (card.deck_limit || 0) > 0 &&
       investigatorsByName[card.real_name]?.length > 1
     ) {
       for (const investigator of investigatorsByName[card.real_name]) {

--- a/src/store/lib/lookup-tables.ts
+++ b/src/store/lib/lookup-tables.ts
@@ -371,7 +371,7 @@ export function createRelations(metadata: Metadata, tables: LookupTables) {
     // Index multi-class investigators.
     if (
       card.type_code === "investigator" &&
-      (card.deck_limit || 0) > 0 &&
+      card.deck_limit &&
       investigatorsByName[card.real_name]?.length > 1
     ) {
       for (const investigator of investigatorsByName[card.real_name]) {


### PR DESCRIPTION
fix: it will not appear in other versions of the investigator if deck_limit is 0 or undefined.

ex)
`zsotw_00012a` <-> `zsotw_00012b`