### PR TITLE
Fix: Rollback limited cardpool investigator select

### DIFF
--- a/src/components/limited-card-pool/limited-card-pool.tsx
+++ b/src/components/limited-card-pool/limited-card-pool.tsx
@@ -1,6 +1,9 @@
 import { useStore } from "@/store";
 import type { SealedDeck } from "@/store/lib/types";
-import { selectPackOptions } from "@/store/selectors/lists";
+import {
+  selectLimitedPoolPackOptions,
+  selectPackOptions,
+} from "@/store/selectors/lists";
 import { selectMetadata } from "@/store/selectors/shared";
 import type { Pack } from "@/store/services/queries.types";
 import type { StoreState } from "@/store/slices";
@@ -102,7 +105,7 @@ export function LimitedCardPoolField(props: {
   const { onValueChange, selectedItems } = props;
   const { t } = useTranslation();
 
-  const packs = useStore(selectPackOptions);
+  const packs = useStore(selectLimitedPoolPackOptions);
 
   const items = useMemo(
     () =>

--- a/src/store/selectors/lists.ts
+++ b/src/store/selectors/lists.ts
@@ -1105,6 +1105,22 @@ export const selectPackOptions = createSelector(
   },
 );
 
+export const selectLimitedPoolPackOptions = createSelector(
+  selectCyclesAndPacks,
+  selectActiveList,
+  (cycles, list) => {
+    return cycles.flatMap((cycle) => {
+      if (cycle.reprintPacks.length && cycle.code !== "core") {
+        return filterNewFormat(cycle.reprintPacks, list?.cardType);
+      }
+
+      return cycle.official !== false && cycle.packs.length === 2
+        ? filterNewFormat(cycle.packs, list?.cardType)
+        : [...cycle.reprintPacks, ...cycle.packs];
+    });
+  },
+);
+
 /**
  * Properties
  */


### PR DESCRIPTION
Fixing Return to packs not appearing in Limited Cardpool Select even when in collection.

See: https://discord.com/channels/225349059689447425/1264242716179431670/1383833073971630222
