### PR TITLE
Replace trait chart tooltip with foldable list

### DIFF
--- a/src/components/deck-tools/deck-tools.module.css
+++ b/src/components/deck-tools/deck-tools.module.css
@@ -47,34 +47,6 @@
   margin-bottom: calc(24px + 0.375rem);
 }
 
-.trait {
-  font-style: italic;
-  font-family: var(--font-family-content);
-
-  &::after {
-    content: ".";
-  }
-}
-
-.trait-tooltip {
-  padding: 0.125rem;
-}
-
-.trait-tooltip > * + * {
-  margin-top: 0.125rem;
-}
-
-.trait-chart-trait-title span {
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-}
-
-.trait-chart-item-details-list {
-  margin-left: 2.5rem;
-  margin-top: 0.25rem;
-  margin-bottom: 0.5rem;
-}
-
 .table-container {
   max-height: 330px;
   width: 100%;
@@ -105,8 +77,8 @@
   border-bottom: 1px solid var(--palette-2);
 }
 
-.table :where(tr:not(.table-no-hover):hover) {
-  background-color: var(--palette-3);
+.table :where(tr:not(.open):hover) {
+  background-color: var(--palette-1);
 }
 
 .table :where(th, td):not(:last-child) {
@@ -119,13 +91,44 @@
 
 .trait-chart-column-trait {
   width: 100%;
+  padding: 0;
+}
+
+.trait-chart-title {
+  display: flex;
+  background: none;
+  width: 100%;
+  justify-content: flex-start;
+  font-size: var(--text-small);
+  padding: 0.375rem;
+  gap: 0.375rem;
 }
 
 .trait-chart-column-count {
-  width: auto;
   padding-right: 0.75rem;
-  vertical-align: top;
   text-align: right;
+  vertical-align: baseline;
+}
+
+.trait {
+  font-style: italic;
+  font-family: var(--font-family-content);
+
+  &::after {
+    content: ".";
+  }
+}
+
+.trait-chart-item-details-list {
+  margin: 0.375rem;
+}
+
+.trait-tooltip {
+  padding: 0.125rem;
+}
+
+.trait-tooltip > * + * {
+  margin-top: 0.125rem;
 }
 
 @media screen and (max-width: 75rem) {

--- a/src/components/deck-tools/deck-tools.module.css
+++ b/src/components/deck-tools/deck-tools.module.css
@@ -91,6 +91,9 @@
 
 .trait-chart-column-trait {
   width: 100%;
+}
+
+td.trait-chart-column-trait {
   padding: 0;
 }
 

--- a/src/components/deck-tools/deck-tools.module.css
+++ b/src/components/deck-tools/deck-tools.module.css
@@ -64,8 +64,19 @@
   margin-top: 0.125rem;
 }
 
+.trait-chart-trait-title span {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.trait-chart-item-details-list {
+  margin-left: 2.5rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
 .table-container {
-  max-height: 250px;
+  max-height: 330px;
   width: 100%;
 }
 
@@ -94,7 +105,7 @@
   border-bottom: 1px solid var(--palette-2);
 }
 
-.table :where(tr:hover) {
+.table :where(tr:not(.table-no-hover):hover) {
   background-color: var(--palette-3);
 }
 
@@ -104,6 +115,17 @@
 
 .table tr:not(:last-child) {
   border-bottom: 1px solid var(--palette-2);
+}
+
+.trait-chart-column-trait {
+  width: 100%;
+}
+
+.trait-chart-column-count {
+  width: auto;
+  padding-right: 0.75rem;
+  vertical-align: top;
+  text-align: right;
 }
 
 @media screen and (max-width: 75rem) {

--- a/src/components/deck-tools/traits-chart.tsx
+++ b/src/components/deck-tools/traits-chart.tsx
@@ -8,8 +8,13 @@ import {
 } from "@/store/selectors/shared";
 import type { Card } from "@/store/services/queries.types";
 import { cx } from "@/utils/cx";
+import { Content, Root, Trigger } from "@radix-ui/react-collapsible";
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { ListCard } from "../list-card/list-card";
 import { ListCardInner } from "../list-card/list-card-inner";
+import { Button } from "../ui/button";
 import { Scroller } from "../ui/scroller";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import css from "./deck-tools.module.css";
@@ -22,7 +27,7 @@ type Props = {
 export function TraitsChart(props: Props) {
   const { data, deck } = props;
 
-  const { i18n, t } = useTranslation();
+  const { t } = useTranslation();
 
   return (
     <div className={cx(css["chart-container"], css["traits"])}>
@@ -31,29 +36,17 @@ export function TraitsChart(props: Props) {
         <table className={css["table"]}>
           <thead>
             <tr>
-              <th>{t("common.trait", { count: 1 })}</th>
-              <th>{t("deck.tools.count")}</th>
+              <th className={css["trait-chart-column-trait"]}>
+                {t("common.trait", { count: 1 })}
+              </th>
+              <th className={css["trait-chart-column-count"]}>
+                {t("deck.tools.count")}
+              </th>
             </tr>
           </thead>
           <tbody>
             {data.map((trait) => (
-              <Tooltip delay={200} key={trait.x}>
-                <TooltipTrigger asChild>
-                  <tr>
-                    <td>
-                      <span className={css["trait"]}>
-                        {i18n.exists(`common.traits.${trait.x}`)
-                          ? t(`common.traits.${trait.x}`)
-                          : trait.x}
-                      </span>
-                    </td>
-                    <td>{trait.y}</td>
-                  </tr>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <TraitsChartTooltip deck={deck} trait={trait} />
-                </TooltipContent>
-              </Tooltip>
+              <TraitsChartRow key={trait.x} deck={deck} trait={trait} />
             ))}
           </tbody>
         </table>
@@ -62,7 +55,7 @@ export function TraitsChart(props: Props) {
   );
 }
 
-function TraitsChartTooltip({
+function TraitsChartRow({
   deck,
   trait,
 }: {
@@ -72,7 +65,11 @@ function TraitsChartTooltip({
   const metadata = useStore(selectMetadata);
   const collator = useStore(selectLocaleSortingCollator);
 
-  const matches = Object.values(deck.cards.slots)
+  const { i18n, t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const settings = useStore((state) => state.settings);
+
+  const cards = Object.values(deck.cards.slots)
     .reduce((acc, { card }) => {
       if (card.real_traits?.includes(trait.x)) acc.push(card);
       return acc;
@@ -80,8 +77,65 @@ function TraitsChartTooltip({
     .sort(makeSortFunction(["name", "level", "position"], metadata, collator));
 
   return (
+    <tr className={open ? css["table-no-hover"] : css["table-hover"]}>
+      <td className={css["trait-chart-column-trait"]}>
+        <Root open={open} onOpenChange={setOpen}>
+          <div className={css["trait-chart-trait-title"]}>
+            <Trigger>
+              <Button
+                tooltip={
+                  open
+                    ? t("ui.collapsible.collapse")
+                    : t("ui.collapsible.expand")
+                }
+                variant="bare"
+                size="xs"
+              >
+                {open ? <ChevronUpIcon /> : <ChevronDownIcon />}
+              </Button>
+              <Tooltip delay={200} key={trait.x}>
+                <TooltipTrigger asChild>
+                  <span className={css["trait"]}>
+                    {i18n.exists(`common.traits.${trait.x}`)
+                      ? t(`common.traits.${trait.x}`)
+                      : trait.x}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <TraitsChartTooltip deck={deck} cards={cards} />
+                </TooltipContent>
+              </Tooltip>
+            </Trigger>
+          </div>
+          <Content className={css["trait-chart-item-details"]}>
+            <ol className={css["trait-chart-item-details-list"]}>
+              {cards.map((card) => (
+                <ListCard
+                  card={card}
+                  cardLevelDisplay={settings.cardLevelDisplay}
+                  key={card.code}
+                  quantity={deck.slots[card.code]}
+                />
+              ))}
+            </ol>
+          </Content>
+        </Root>
+      </td>
+      <td className={css["trait-chart-column-count"]}>{trait.y}</td>
+    </tr>
+  );
+}
+
+function TraitsChartTooltip({
+  deck,
+  cards,
+}: {
+  deck: ResolvedDeck;
+  cards: Card[];
+}) {
+  return (
     <ol className={css["trait-tooltip"]}>
-      {matches.map((card) => (
+      {cards.map((card) => (
         <ListCardInner
           card={card}
           cardLevelDisplay="icon-only"

--- a/src/components/deck-tools/traits-chart.tsx
+++ b/src/components/deck-tools/traits-chart.tsx
@@ -14,9 +14,8 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ListCard } from "../list-card/list-card";
 import { ListCardInner } from "../list-card/list-card-inner";
-import { Button } from "../ui/button";
 import { Scroller } from "../ui/scroller";
-import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+import { DefaultTooltip } from "../ui/tooltip";
 import css from "./deck-tools.module.css";
 
 type Props = {
@@ -67,7 +66,6 @@ function TraitsChartRow({
 
   const { i18n, t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const settings = useStore((state) => state.settings);
 
   const cards = Object.values(deck.cards.slots)
     .reduce((acc, { card }) => {
@@ -77,44 +75,32 @@ function TraitsChartRow({
     .sort(makeSortFunction(["name", "level", "position"], metadata, collator));
 
   return (
-    <tr className={open ? css["table-no-hover"] : css["table-hover"]}>
+    <tr className={open ? css["open"] : css["closed"]}>
       <td className={css["trait-chart-column-trait"]}>
         <Root open={open} onOpenChange={setOpen}>
-          <div className={css["trait-chart-trait-title"]}>
-            <Trigger>
-              <Button
-                tooltip={
-                  open
-                    ? t("ui.collapsible.collapse")
-                    : t("ui.collapsible.expand")
-                }
-                variant="bare"
-                size="xs"
-              >
+          <DefaultTooltip
+            tooltip={<TraitsChartTooltip deck={deck} cards={cards} />}
+            paused={open}
+          >
+            <Trigger asChild>
+              <button className={css["trait-chart-title"]} type="button">
                 {open ? <ChevronUpIcon /> : <ChevronDownIcon />}
-              </Button>
-              <Tooltip delay={200} key={trait.x}>
-                <TooltipTrigger asChild>
-                  <span className={css["trait"]}>
-                    {i18n.exists(`common.traits.${trait.x}`)
-                      ? t(`common.traits.${trait.x}`)
-                      : trait.x}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <TraitsChartTooltip deck={deck} cards={cards} />
-                </TooltipContent>
-              </Tooltip>
+                <span className={css["trait"]}>
+                  {i18n.exists(`common.traits.${trait.x}`)
+                    ? t(`common.traits.${trait.x}`)
+                    : trait.x}
+                </span>
+              </button>
             </Trigger>
-          </div>
+          </DefaultTooltip>
           <Content className={css["trait-chart-item-details"]}>
             <ol className={css["trait-chart-item-details-list"]}>
               {cards.map((card) => (
                 <ListCard
                   card={card}
-                  cardLevelDisplay={settings.cardLevelDisplay}
                   key={card.code}
                   quantity={deck.slots[card.code]}
+                  size="sm"
                 />
               ))}
             </ol>

--- a/src/components/deck-tools/traits-chart.tsx
+++ b/src/components/deck-tools/traits-chart.tsx
@@ -101,6 +101,7 @@ function TraitsChartRow({
                   key={card.code}
                   quantity={deck.slots[card.code]}
                   size="sm"
+                  omitBorders
                 />
               ))}
             </ol>


### PR DESCRIPTION
This makes it easier to check the cards from a trait
- can be clicked for the full view
- more room to display icon, cost, ...
